### PR TITLE
Fixed missing feature ID

### DIFF
--- a/src/ditto/protocol/things/commands.py
+++ b/src/ditto/protocol/things/commands.py
@@ -97,16 +97,16 @@ class Command(_Signal):
         self.path = _Signal._path_thing_feature_definition_format.format(feature_id)
         return self
 
-    def feature_properties(self) -> 'Command':
-        self.path = _Signal._path_thing_feature_properties_format
+    def feature_properties(self, feature_id: str) -> 'Command':
+        self.path = _Signal._path_thing_feature_properties_format.format(feature_id)
         return self
 
     def feature_property(self, feature_id: str, property_path: str) -> 'Command':
         self.path = _Signal._path_thing_feature_property_format.format(feature_id, property_path)
         return self
 
-    def feature_desired_properties(self) -> 'Command':
-        self.path = _Signal._path_thing_feature_desired_properties_format
+    def feature_desired_properties(self, feature_id: str) -> 'Command':
+        self.path = _Signal._path_thing_feature_desired_properties_format.format(feature_id)
         return self
 
     def feature_desired_property(self, feature_id: str, desired_property_path: str) -> 'Command':


### PR DESCRIPTION
Added missing function argument feature_id when addressing all properties
and desired properties of a feature in a command.

Signed-off-by: Ognian Baruh <fixed-term.Ognyan.Baruh@bosch.io>