### PR TITLE
Fixed twin channel selection 

### DIFF
--- a/src/ditto/protocol/things/commands.py
+++ b/src/ditto/protocol/things/commands.py
@@ -262,3 +262,4 @@ class Command(_Signal):
         :rtype: Command
         """
         self.topic.with_channel(Topic.CHANNEL_TWIN)
+        return self

--- a/src/ditto/protocol/things/events.py
+++ b/src/ditto/protocol/things/events.py
@@ -251,3 +251,4 @@ class Event(_Signal):
         :rtype: Event
         """
         self.topic.with_channel(Topic.CHANNEL_TWIN)
+        return self


### PR DESCRIPTION
Fixed twin channel selection when creating/modifying a command or an event.

Signed-off-by: Gabriela Yoncheva <fixed-term.Gabriela.Yoncheva@bosch.io>